### PR TITLE
Make macros work without simple_error::SimpleError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This project roughly adheres to [Semantic Versioning](http://semver.org/). For 0.x.y releases, `x` is the major version in semver, while `y` is the minor version.
 
+
+## 0.1.12 - 2018-10-11
+
+* Make `try_with`, `require_with` and `bail` work without requiring `using simple_error::SimpleError`
+
 ## 0.1.11 - 2018-03-31
 
 * Support format string in `try_with` and `require_with`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-error"
-version = "0.1.11"
+version = "0.1.12"
 authors = ["Wangshan Lu <wisagan@gmail.com>"]
 license = "MIT/Apache-2.0"
 readme = "README.md"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,13 +164,13 @@ macro_rules! try_with {
     ($expr: expr, $str: expr) => (match $expr {
         Ok(val) => val,
         Err(err) => {
-            return Err(SimpleError::with($str.as_ref(), err));
+            return Err($crate::SimpleError::with($str.as_ref(), err));
         },
     });
     ($expr: expr, $fmt:expr, $($arg:tt)+) => (match $expr {
         Ok(val) => val,
         Err(err) => {
-            return Err(SimpleError::with(&format!($fmt, $($arg)+), err));
+            return Err($crate::SimpleError::with(&format!($fmt, $($arg)+), err));
         },
     });
 }
@@ -214,13 +214,13 @@ macro_rules! require_with {
     ($expr: expr, $str: expr) => (match $expr {
         Some(val) => val,
         None => {
-            return Err(SimpleError::new($str.as_ref()));
+            return Err($crate::SimpleError::new($str.as_ref()));
         },
     });
     ($expr: expr, $fmt:expr, $($arg:tt)+) => (match $expr {
         Some(val) => val,
         None => {
-            return Err(SimpleError::new(format!($fmt, $($arg)+)));
+            return Err($crate::SimpleError::new(format!($fmt, $($arg)+)));
         },
     });
 }
@@ -265,7 +265,7 @@ macro_rules! bail {
         return Err($e.into());
     };
     ($fmt:expr, $($arg:tt)+) => {
-        return Err(SimpleError::new(format!($fmt, $($arg)+)));
+        return Err($crate::SimpleError::new(format!($fmt, $($arg)+)));
     };
 }
 


### PR DESCRIPTION
I found I was getting weird errors because macros use SimpleError raw. From my (very limited) rust knowledge, the correct solution for this is to use $crate.

The only possible negative effect of this I am aware of is that users might get warnings saying that now they don't need the import any more, like:

```
warning: unused import: `simple_error::SimpleError`
  --> src/main.rs:23:5
   |
23 | use simple_error::SimpleError;
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: #[warn(unused_imports)] on by default
```
