### PR TITLE
Fix do_bar() README example undeclared io and missing new fn

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ You can use it to replace all error types if you only care about a string descri
 
 ```rust
 fn do_bar() -> Result<(), SimpleError> {
-    SimpleError::from(std::io::Error(io::ErrorKind::Other, "oh no"))
+    SimpleError::from(std::io::Error::new(std::io::ErrorKind::Other, "oh no"))
 }
 ```
 


### PR DESCRIPTION
Note that the missing Err() per the return type is
already addressed in PR #12 and thus not addressed here